### PR TITLE
T-973: Handle `considering` status

### DIFF
--- a/src/components/PublicRoadmap.astro
+++ b/src/components/PublicRoadmap.astro
@@ -19,7 +19,7 @@ const tasks: Task[] = await fetch(PUBLIC_ROADMAP_ENDPOINT).then(res => res.json(
   {tasks.map(({ id, name, description, status }) => {
     let variant: BadgeComponentProps["variant"] = 'note';
     if (status === 'in-progress') variant = 'caution';
-    if (status === 'done') variant = 'success';
+    if (status === 'considering') variant = 'tip';
     
     return (<li id={id}>
       <article class="row">

--- a/src/pages/roadmap.mdx
+++ b/src/pages/roadmap.mdx
@@ -11,11 +11,9 @@ import PublicRoadmap from "../components/PublicRoadmap.astro";
   }}
 >
 
-{/* TODO: replace github link with /share link */}
-This roadmap is generated dynamically from a <a href="https://github.com/membrane-io/operations/tree/main/public-roadmap" target="_blank">Membrane program we wrote</a> to fetch tasks from our `public-roadmap` list in <a href="https://height.app/product" target="_blank">Height</a>.
+This roadmap is generated dynamically from a <a href="https://www.membrane.io/share/membrane/public-roadmap" target="_blank">Membrane program we wrote</a> to fetch tasks from our `public-roadmap` list in <a href="https://height.app/product" target="_blank">Height</a>.
 
-{/* TODO: replace github link with /share link */}
-That program uses the <a href="https://github.com/membrane-io/membrane-driver-height" target="_blank">height driver</a>, which simplifies interacting with Height's API. Feel free to fork the program! Or if you'd like to set up something similar for a different tool (e.g. <a href="https://linear.app" target="_blank">Linear</a>), reach out to us <a href="https://discord.gg/sbRcqC7QxE" target="_blank">on Discord</a>—we'd be happy to help.
+That program uses the <a href="https://www.membrane.io/share/membrane/height" target="_blank">height driver</a>, which simplifies interacting with Height's API. Feel free to fork the program! Or if you'd like to set up something similar for a different tool (e.g. <a href="https://linear.app" target="_blank">Linear</a>), reach out to us <a href="https://discord.gg/sbRcqC7QxE" target="_blank">on Discord</a>—we'd be happy to help.
 
 :::tip
 You can nudge us to work on a task by clicking the `upvote` button below its description, and/or add your thoughts via the `feedback` button.

--- a/src/pages/roadmap.mdx
+++ b/src/pages/roadmap.mdx
@@ -11,8 +11,10 @@ import PublicRoadmap from "../components/PublicRoadmap.astro";
   }}
 >
 
+{/* TODO: replace github link with /share link */}
 This roadmap is generated dynamically from a <a href="https://github.com/membrane-io/operations/tree/main/public-roadmap" target="_blank">Membrane program we wrote</a> to fetch tasks from our `public-roadmap` list in <a href="https://height.app/product" target="_blank">Height</a>.
 
+{/* TODO: replace github link with /share link */}
 That program uses the <a href="https://github.com/membrane-io/membrane-driver-height" target="_blank">height driver</a>, which simplifies interacting with Height's API. Feel free to fork the program! Or if you'd like to set up something similar for a different tool (e.g. <a href="https://linear.app" target="_blank">Linear</a>), reach out to us <a href="https://discord.gg/sbRcqC7QxE" target="_blank">on Discord</a>—we'd be happy to help.
 
 :::tip


### PR DESCRIPTION
The original reason I checked out this branch was to update the endpoint URL of the `public-roadmap` program. It aborted a few days ago, so I stopped it, which deleted the program (maybe because the folder was missing—see [T-975](https://membrane.height.app/T-975) and [T-846](https://membrane.height.app/T-846)). So I created a new program and expected a new endpoint URL, but interestingly enough it looks like the original one was stored...

Opening anyway to handle the new `Considering` Height status and point to the published package at [membrane.io/share/membrane/public-roadmap](https://membrane.io/share/membrane/public-roadmap) rather than the github repo.

=============
Close T-973