### PR TITLE
Improve the intro and getting started page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -117,8 +117,8 @@ export default defineConfig({
               link: "/getting-started/intro/",
             },
             {
-              label: "Getting Started",
-              link: "/getting-started/install/",
+              label: "Setup",
+              link: "/getting-started/setup/",
             },
             {
               label: "Hello World",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -117,11 +117,11 @@ export default defineConfig({
               link: "/getting-started/intro/",
             },
             {
-              label: "Installation",
+              label: "Getting Started",
               link: "/getting-started/install/",
             },
             {
-              label: "Create a program",
+              label: "Hello World",
               link: "/getting-started/first-program/",
             },
           ],

--- a/src/content/docs/getting-started/first-program.mdx
+++ b/src/content/docs/getting-started/first-program.mdx
@@ -20,4 +20,4 @@ Creating a new Membrane program from <a href="https://membrane.io/ide" target="_
 
 That's it! The program is immediately deployed. Changes you make are automatically deployed on when you save the file. Try it!
 
-The Next is when things start to get interesting. You'll learn how our durable runtime helps you build long-lived programs without any of the traditional complexities.
+The next page is where things get interesting. You'll learn how our durable runtime helps you build long-lived programs without any of the traditional complexities.

--- a/src/content/docs/getting-started/first-program.mdx
+++ b/src/content/docs/getting-started/first-program.mdx
@@ -4,21 +4,20 @@ title: Creating your first program
 
 import { Steps } from "@astrojs/starlight/components";
 
-Creating a new Membrane program takes two clicks:
-
-<Steps>
-
-1. Open the <a href="https://membrane.io/ide" target="_blank">Membrane IDE</a>.
-2. Click `NEW PROGRAM` and select a template to start from.
-3. That's it! The program is deployed, changes are automatically deployed on save.
-
-</Steps>
-
-<video src="/cloud-assets/new-program.mp4" muted autoplay loop></video>
-
 In this "Hello World" video we create a program and invoke its `run` [action](/concepts/schema#actions). The results of
 the invocation can be seen in the logs.
 
-## Next steps
+<video src="/cloud-assets/new-program.mp4" muted autoplay loop></video>
 
-Next you'll learn how Membrane's durable state helps you build long-lived programs without any of the traditional complexities.
+Creating a new Membrane program from <a href="https://membrane.io/ide" target="_blank">the IDE</a> takes two clicks:
+
+<Steps>
+
+1. Click `NEW PROGRAM`
+2. Click `Action` to create a simple program with just one action. (change the name if you want)
+
+</Steps>
+
+That's it! The program is immediately deployed. Changes you make are automatically deployed on when you save the file. Try it!
+
+The Next is when things start to get interesting. You'll learn how our durable runtime helps you build long-lived programs without any of the traditional complexities.

--- a/src/content/docs/getting-started/first-program.mdx
+++ b/src/content/docs/getting-started/first-program.mdx
@@ -4,20 +4,21 @@ title: Creating your first program
 
 import { Steps } from "@astrojs/starlight/components";
 
-Creating a new Membrane program is easy.
+Creating a new Membrane program takes two clicks:
 
 <Steps>
 
-1. Open the <a href="https://membrane.io/ide" target="_blank">Membrane IDE</a>
-2. Click the `NEW` button and select which type of program you'd like to create
-3. Invoke the `run` action in your new program
+1. Open the <a href="https://membrane.io/ide" target="_blank">Membrane IDE</a>.
+2. Click `NEW PROGRAM` and select a template to start from.
+3. That's it! The program is deployed, changes are automatically deployed on save.
 
 </Steps>
 
 <video src="/cloud-assets/new-program.mp4" muted autoplay loop></video>
 
-In this video we create a program called `new-program`, open its logs, and invoke its `run` [action](/concepts/schema#actions) by selecting the program in the Navigator panel. The results of the invocation can be seen in the logs.
+In this "Hello World" video we create a program and invoke its `run` [action](/concepts/schema#actions). The results of
+the invocation can be seen in the logs.
 
-:::tip
-Learn about stopping and deleting programs in [Concepts > Programs](/concepts/programs#stopping-and-deleting-programs).
-:::
+## Next steps
+
+Next you'll learn how Membrane's durable state helps you build long-lived programs without any of the traditional complexities.

--- a/src/content/docs/getting-started/install.md
+++ b/src/content/docs/getting-started/install.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: Setup
 ---
 
 ## Membrane Web IDE

--- a/src/content/docs/getting-started/install.md
+++ b/src/content/docs/getting-started/install.md
@@ -1,16 +1,16 @@
 ---
-title: Installation
+title: Getting Started
 ---
 
 ## Membrane Web IDE
 
-Membrane's primary interface is the Membrane Web IDE (fork of VS Code). The IDE is where you deploy Membrane programs, set up cron jobs, manually run programs, inspect logs, and more.
+Membrane's primary interface is the Membrane Web IDE. The IDE is where you deploy Membrane programs, set up cron jobs, inspect logs, and more.
 
-Visit <a href="https://membrane.io/ide" target="_blank">membrane.io/ide</a> to sign up and open your Membrane workspace.
+Visit <a href="https://membrane.io/ide" target="_blank">membrane.io/ide</a> to get started.
 
 ### Orienting yourself in the IDE
 
-When the IDE starts up, you'll see Membrane's Program Navigator (sidebar), Program Logs (bottombar), and a welcome/start screen (active tab). The welcome tab provides a quick tour of the Navigator and Logs.
+When the IDE starts up, you'll see the Program Navigator (sidebar), Membrane Logs (bottombar), and a welcome/start screen (active tab). The welcome tab provides a quick tour of the Navigator and Logs.
 
 The welcome tab also links to an interactive `getting-started` tutorial that comes pre-installed in your workspace. We recorded a <a href="https://share.descript.com/view/Smb0rEUzMkk" target="_blank">video walk-through of the tutorial</a> if you'd like to follow along with each step.
 

--- a/src/content/docs/getting-started/intro.md
+++ b/src/content/docs/getting-started/intro.md
@@ -3,20 +3,18 @@ title: Introduction to Membrane
 description: An overview of Membrane and its uses
 ---
 
-<a href="https://www.membrane.io">Membrane</a> is a service that greatly simplify the process of building and deploying
-small applications using TypeScript. Popular use-cases for Membrane are automation using APIs, email, text messages,
-long-lived workflows, cron jobs, webhook handlers, web scraping, chat bots, and many more.
+<a href="https://www.membrane.io">Membrane</a> simplifies the process of building and deploying small applications using TypeScript. Popular use cases for Membrane are automation using APIs, email, text messages, long-lived workflows, cron jobs, webhook handlers, web scraping, chat bots, and many more.
 
 ## What's different?
 
-Membrane's super powers come from a few features that makes it different to other JavaScript/TypeScript environments, most notably:
+Membrane's superpowers come from a few features that differentiate it from other JavaScript/TypeScript environments, most notably:
 
- - Programs are durable: there's no need to store/load data from a database, just keep your normal variables in the `state` object.
+ - Programs are durable: there's no need to store/load data from a database, just keep data you want to save in the `state` object.
  - Access APIs via a unified graph: use external APIs with ease.
- - Everything is in the logs: Our runtime uses a write-ahead log so if it's not in the logs, it didn't happen.
+ - Everything is in the logs: Our runtime uses a write-ahead log, so if it's not in the logs, it didn't happen.
  - Built-in email: every program comes with an email address. Just export an `email` function.
 
-Check out our <a href="https://www.membrane.io">home page</a> for an overview of the main features and examples.
+Check out our <a href="https://www.membrane.io">homepage</a> for an overview of the main features and examples.
 
 <!-- TODO: Add a visualization that communicates what membrane is in a few seconds -->
 

--- a/src/content/docs/getting-started/intro.md
+++ b/src/content/docs/getting-started/intro.md
@@ -3,13 +3,9 @@ title: Introduction to Membrane
 description: An overview of Membrane and its uses
 ---
 
-:::note
-These docs are open source. Feel free to open a PR <a href="https://github.com/membrane-io/docs" target="_blank">on GitHub</a> for fixes/improvements. If you have any questions, please <a href="https://discord.gg/4RHyJDV8kj" target="_blank">reach out to us on Discord</a>.
-:::
-
-Membrane is a service that greatly simplify the process of building and deploying small applications using TypeScript.
-Some use cases for Membrane are automation using APIs, email, text messages, long-lived workflows, cronjobs, webhook
-handlers, scraping, chat bots, and many more.
+<a href="https://www.membrane.io">Membrane</a> is a service that greatly simplify the process of building and deploying
+small applications using TypeScript. Popular use-cases for Membrane are automation using APIs, email, text messages,
+long-lived workflows, cron jobs, webhook handlers, web scraping, chat bots, and many more.
 
 ## What's different?
 
@@ -23,4 +19,12 @@ Membrane's super powers come from a few features that makes it different to othe
 Check out our <a href="https://www.membrane.io">home page</a> for an overview of the main features and examples.
 
 <!-- TODO: Add a visualization that communicates what membrane is in a few seconds -->
+
+## Community
+
+If you have any questions, comments, or ideas, come join us on <a href="https://discord.gg/4RHyJDV8kj" target="_blank">Discord</a> or reach out via `contact@membrane.io`.
+
+:::note
+These docs are open source. Feel free to open a PR <a href="https://github.com/membrane-io/docs" target="_blank">on GitHub</a>. 
+:::
 

--- a/src/content/docs/getting-started/intro.md
+++ b/src/content/docs/getting-started/intro.md
@@ -22,7 +22,7 @@ Check out our <a href="https://www.membrane.io">home page</a> for an overview of
 
 ## Community
 
-If you have any questions, comments, or ideas, come join us on <a href="https://discord.gg/4RHyJDV8kj" target="_blank">Discord</a> or reach out via `contact@membrane.io`.
+Come join us on <a href="https://discord.gg/4RHyJDV8kj" target="_blank">Membrane's Discord</a> or reach out via `contact@membrane.io`. We'll help you get set up and show you around.
 
 :::note
 These docs are open source. Feel free to open a PR <a href="https://github.com/membrane-io/docs" target="_blank">on GitHub</a>. 

--- a/src/content/docs/getting-started/intro.md
+++ b/src/content/docs/getting-started/intro.md
@@ -7,12 +7,20 @@ description: An overview of Membrane and its uses
 These docs are open source. Feel free to open a PR <a href="https://github.com/membrane-io/docs" target="_blank">on GitHub</a> for fixes/improvements. If you have any questions, please <a href="https://discord.gg/4RHyJDV8kj" target="_blank">reach out to us on Discord</a>.
 :::
 
-<a href="https://www.membrane.io" target="_blank">membrane.io</a> is a serverless JavaScript and TypeScript runtime for building automations and integrations. Membrane programs are deployed and managed directly through the [Membrane Web IDE](/getting-started/install#membrane-web-ide).
+Membrane is a service that greatly simplify the process of building and deploying small applications using TypeScript.
+Some use cases for Membrane are automation using APIs, email, text messages, long-lived workflows, cronjobs, webhook
+handlers, scraping, chat bots, and many more.
 
-Membrane significantly lowers friction to run cron jobs and workflows, create Discord and Slack bots, poll websites, handle webhooks, and more.
+## What's different?
+
+Membrane's super powers come from a few features that makes it different to other JavaScript/TypeScript environments, most notably:
+
+ - Programs are durable: there's no need to store/load data from a database, just keep your normal variables in the `state` object.
+ - Access APIs via a unified graph: use external APIs with ease.
+ - Everything is in the logs: Our runtime uses a write-ahead log so if it's not in the logs, it didn't happen.
+ - Built-in email: every program comes with an email address. Just export an `email` function.
+
+Check out our <a href="https://www.membrane.io">home page</a> for an overview of the main features and examples.
 
 <!-- TODO: Add a visualization that communicates what membrane is in a few seconds -->
 
-## Where to start
-
-If you'd like to read more about Membrane's features and architecture before diving in, start with [Durable State](/features/state). Or if you'd prefer to browse examples first, head to <a href="https://www.membrane.io/example-sms-reminders" target="_blank">membrane.io</a> or check out our <a href="https://github.com/membrane-io/directory" target="_blank">directory</a> of examples and API drivers on GitHub.

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -80,22 +80,6 @@
   --sl-color-text-accent: #000;
 }
 
-/* /* Override icon colors and add Membrane's distinctive box-shadow */
-*/
-/* :root[data-theme="light"] { */
-/*   --sl-icon-color: #333; */
-/*   --sl-shadow-md: 1px 1px #222, 2px 2px #222, 3px 3px #222, 4px 4px #222, */
-/*     5px 5px #222; */
-/*   --sl-shadow-lg: var(--sl-shadow-md); */
-/* } */
-/* :root[data-theme="dark"] { */
-/*   --sl-icon-color: #fff; */
-/*   --sl-shadow-md: 1px 1px var(--sl-color-gray-4), 2px 2px var(--sl-color-gray-4), */
-/*     3px 3px var(--sl-color-gray-4), 4px 4px var(--sl-color-gray-4), */
-/*     5px 5px var(--sl-color-gray-4); */
-/*   --sl-shadow-lg: var(--sl-shadow-md); */
-/* } */
-
 /* Override to center content body at larger widths */
 @media (min-width: 72rem) {
   [data-has-sidebar][data-has-toc] .main-pane > main {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -23,20 +23,78 @@
   --sl-line-height: 1.4;
 }
 
-/* Override icon colors and add Membrane's distinctive box-shadow */
-:root[data-theme="light"] {
-  --sl-icon-color: #333;
-  --sl-shadow-md: 1px 1px #222, 2px 2px #222, 3px 3px #222, 4px 4px #222,
-    5px 5px #222;
-  --sl-shadow-lg: var(--sl-shadow-md);
-}
+/* Dark mode colors. */
 :root[data-theme="dark"] {
-  --sl-icon-color: #fff;
-  --sl-shadow-md: 1px 1px var(--sl-color-gray-4), 2px 2px var(--sl-color-gray-4),
-    3px 3px var(--sl-color-gray-4), 4px 4px var(--sl-color-gray-4),
-    5px 5px var(--sl-color-gray-4);
-  --sl-shadow-lg: var(--sl-shadow-md);
+  --sl-color-accent-low: #242424;
+  --sl-color-accent: #6a6a6a;
+  --sl-color-accent-high: #c8c8c8;
+  --sl-color-white: #ffffff;
+  --sl-color-gray-1: #eeeeee;
+  --sl-color-gray-2: #c2c2c2;
+  --sl-color-gray-3: #8b8b8b;
+  --sl-color-gray-4: #585858;
+  --sl-color-gray-5: #383838;
+  --sl-color-gray-6: #272727;
+  --sl-color-black: #181818;
+  --sl-color-blue-low: #000;
+
+  --sl-color-blue: #fff;
+  --sl-color-blue-low: #111;
+  --sl-color-blue-high: #fff;
+
+  --sl-color-purple: #fff;
+  --sl-color-purple-low: #111;
+  --sl-color-purple-high: #fff;
+
+  --sl-color-text-accent: #fff;
+  --sl-color-bg: #141414;
+  --sl-color-bg-nav: #141414;
+  --sl-color-bg-sidebar: #141414;
+  --sl-color-hairline-shade: #242424;
+  --sl-color-hairline: #242424;
 }
+
+/* Light mode colors. */
+:root[data-theme="light"] {
+  --sl-color-accent-low: #d7d7d7;
+  --sl-color-accent: #6b6b6b;
+  --sl-color-accent-high: #323232;
+  --sl-color-white: #181818;
+  --sl-color-gray-1: #272727;
+  --sl-color-gray-2: #383838;
+  --sl-color-gray-3: #585858;
+  --sl-color-gray-4: #8b8b8b;
+  --sl-color-gray-5: #c2c2c2;
+  --sl-color-gray-6: #eeeeee;
+  --sl-color-gray-7: #f6f6f6;
+  --sl-color-black: #ffffff;
+
+  --sl-color-blue: #000;
+  --sl-color-blue-low: #eee;
+  --sl-color-blue-high: #000;
+
+  --sl-color-purple: #000;
+  --sl-color-purple-low: #eee;
+  --sl-color-purple-high: #000;
+
+  --sl-color-text-accent: #000;
+}
+
+/* /* Override icon colors and add Membrane's distinctive box-shadow */
+*/
+/* :root[data-theme="light"] { */
+/*   --sl-icon-color: #333; */
+/*   --sl-shadow-md: 1px 1px #222, 2px 2px #222, 3px 3px #222, 4px 4px #222, */
+/*     5px 5px #222; */
+/*   --sl-shadow-lg: var(--sl-shadow-md); */
+/* } */
+/* :root[data-theme="dark"] { */
+/*   --sl-icon-color: #fff; */
+/*   --sl-shadow-md: 1px 1px var(--sl-color-gray-4), 2px 2px var(--sl-color-gray-4), */
+/*     3px 3px var(--sl-color-gray-4), 4px 4px var(--sl-color-gray-4), */
+/*     5px 5px var(--sl-color-gray-4); */
+/*   --sl-shadow-lg: var(--sl-shadow-md); */
+/* } */
 
 /* Override to center content body at larger widths */
 @media (min-width: 72rem) {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -20,7 +20,7 @@
 :root {
   --__sl-font: "Source Sans 3", sans-serif;
   --__sl-font-mono: "MonoRegular", monospace;
-  --sl-line-height: 1.4;
+  --sl-line-height: 1.5;
 }
 
 /* Dark mode colors. */

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -28,8 +28,8 @@
   --sl-color-accent-low: #242424;
   --sl-color-accent: #6a6a6a;
   --sl-color-accent-high: #c8c8c8;
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #eeeeee;
+  --sl-color-white: #eee;
+  --sl-color-gray-1: #ddd;
   --sl-color-gray-2: #c2c2c2;
   --sl-color-gray-3: #8b8b8b;
   --sl-color-gray-4: #585858;


### PR DESCRIPTION
I was just reading the logs and realized that the first three pages are a bit outdated and not highlighting the important aspects of Membrane.

I also tweaked the theme a little bit to move away from the generic Starlight look.

I also felt like the Membrane solid box shadow didn't really fit the giant navigation buttons so I just removed it. 

![Screenshot 2024-10-12 at 21 44 24@2x](https://github.com/user-attachments/assets/35ee95d8-38e8-4853-a2ba-057eda3e8345)

