### PR TITLE
Add `vercel.json` with CORP header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-site"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In order to embed docs.membrane.io as a webview in membrane.io/ide, we need to set this CORS header: `Cross-Origin-Resource-Policy: same-site`.

For reference: [`vercel.json` docs](https://vercel.com/docs/projects/project-configuration#headers)