### PR TITLE
Use `cross-origin` CORP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Cross-Origin-Resource-Policy",
-          "value": "same-site"
+          "value": "cross-origin"
         }
       ]
     }


### PR DESCRIPTION
`https://docs.membrane.io` and `https://membrane.io/ide` are actually different origins, so we need a more relaxed cross-origin resource policy to allow embedding docs in the IDE