### PR TITLE
Add cross-origin-embedder-policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
         {
           "key": "Cross-Origin-Resource-Policy",
           "value": "cross-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
         }
       ]
     }


### PR DESCRIPTION
Because membrane.io/ide has Cross-Origin Embedder Policy (COEP) enabled, each embedded iframe also needs the COEP header. See also #53 