### PR TITLE
Remove link to tutorial video

### DIFF
--- a/src/content/docs/getting-started/hello-world.mdx
+++ b/src/content/docs/getting-started/hello-world.mdx
@@ -27,7 +27,7 @@ Creating a new Membrane program is simple:
 That's it! The program is immediately deployed whenever you save the file. You can also start with one of our templates for a cronjob, API, webhook handler, emailer, or website.
 
 :::tip
-We also have a [`getting-started`](https://www.membrane.io/share/membrane/getting-started) tutorial (and <a href="https://share.descript.com/view/Smb0rEUzMkk" target="_blank">video walk-through</a>) if you'd prefer a hands-on way to learn core features and concepts.
+We also have a [`getting-started`](https://www.membrane.io/share/membrane/getting-started) tutorial if you'd prefer a hands-on way to learn core features and concepts.
 :::
 
 ## Sharing your code


### PR DESCRIPTION
The `getting-started` tutorial walk-through video from a few months ago is a bit stale. Removing it until we re-record.