### PR TITLE
Fix formatting on package installation docs

### DIFF
--- a/src/content/docs/concepts/packages.md
+++ b/src/content/docs/concepts/packages.md
@@ -10,7 +10,7 @@ We're excited to see what you build! Post your share link on [Discord](https://d
 
 ## Installing
 
-To install a package, select `🔎 SEARCH" in Navigator (top left), find the package you want to install, and click `INSTALL`.
+To install a package, select `🔎 SEARCH` in Navigator (top left), find the package you want to install, and click `INSTALL`.
 
 ## Publishing
 


### PR DESCRIPTION
Missing backtick on [docs.membrane.io/concepts/packages/#installing](https://docs.membrane.io/concepts/packages/#installing) is causing a formatting issue.