### PR TITLE
Make docs site more Membrane-y

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -103,7 +103,7 @@ export default defineConfig({
       },
       social: {
         discord: "https://discord.gg/4RHyJDV8kj",
-        github: "https://github.com/withastro/starlight",
+        github: "https://github.com/membrane-io/docs",
         twitter: "https://twitter.com/membraneio",
       },
       plugins: [starlightLinksValidator()],
@@ -127,7 +127,7 @@ export default defineConfig({
         },
         {
           label: "Features",
-          collapsed: true,
+          collapsed: false,
           items: [
             {
               label: "Durable state",
@@ -156,8 +156,8 @@ export default defineConfig({
           ],
         },
         {
-          label: "Membrane-isms",
-          collapsed: true,
+          label: "Concepts",
+          collapsed: false,
           items: [
             {
               label: "Programs",

--- a/src/content/docs/concepts/programs.mdx
+++ b/src/content/docs/concepts/programs.mdx
@@ -6,7 +6,7 @@ import { FileTree } from "@astrojs/starlight/components";
 
 Membrane is similar to an operating system; you deploy programs to the Membrane engine, and it takes care of persistence, communication, logging, resources, etc.
 
-A Membrane _program_ is TypeScript or JavaScript code that runs in Membrane's serverless cloud runtime. Unlike traditional serverless runtimes, it is [stateful](/features/state/) and includes multiple handlers instead of a single function.
+A Membrane _program_ is TypeScript or JavaScript code that runs our cloud runtime. Unlike traditional serverless runtimes, it is [stateful](/features/state/) and includes multiple handlers instead of a single function.
 
 A Membrane program consists of:
 
@@ -39,12 +39,10 @@ Your program's directory may also include a `README.md`, `package.json` with npm
 
 To stop a running program, right click the program in the Membrane Navigator and select `Kill` from the dropdown menu. A program must be stopped in order to delete it.
 
-:::caution
-When you stop a running program, its `state` will be lost.
-:::
-
 To delete a program, right click the program's folder in your file explorer and select `Delete` from the dropdown menu. Or, open the command palette (`Cmd+Shift+P` on Mac) and type _Membrane: Delete Program_. A message will appear in the bottom bar of your editor upon deletion.
 
 :::danger
+When you stop a running program, its `state` will be lost.
+
 Deleting a program is a permanent action.
 :::

--- a/src/content/docs/features/endpoints.md
+++ b/src/content/docs/features/endpoints.md
@@ -29,7 +29,7 @@ declare module "membrane" {
 }
 
 // ---cut---
-export const endpoint: resolvers.Root["endpoint"] = (req) => {
+export const endpoint = (req) => {
   switch (`${req.method} ${req.path}`) {
     case "GET /":
       return "hello world";

--- a/src/content/docs/reference/cli.md
+++ b/src/content/docs/reference/cli.md
@@ -24,41 +24,34 @@ USAGE:
     mctl [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
-    -h, --host <HOST>              API hostname to use [default: api.membrane.io]
+    -h, --host <HOST>              API hostname to use
         --help                     Print help information
     -p, --port <PORT>              API port to use [default: 443]
-        --rpc                      Whether to output machine-readable JSON instead of text
+        --rpc                      Whether to output machine-readable
+                                   JSON instead of text
     -V, --version                  Print version information
-    -w, --workspace <WORKSPACE>    Path to Membrane workspace to use [default:
-                                   /Users/just-be/membrane]
+    -w, --workspace <WORKSPACE>    Path to Membrane workspace to use
 
 SUBCOMMANDS:
     action                   Invokes an action on a node
-    assign                   Assigns a program to a particular mnode (admin only)
-    auth-token               Prints the auth token from the config file
-    clone                    Clones an existing program creating a brand new one in your
-                                 workspace and updates it
-    create                   Create a new program
-    details                  Fetches the detail of an item by its "seq" number
-    exit-node                Starts an HTTP exit node. Outgoing traffic from all programs will
-                                 be routed through this computer
-    get-transpiled-source    Downloads the transpiled source code of a running program
-    git-clone                Clones a program from a github repo to your workspace
-    help                     Print this message or the help of the given subcommand(s)
-    ide                      Opens your Membrane workspace in Visual Studio Code ensuring the
-                                 extension is installed
+    auth-token               Prints the auth token from the config
+                             file
+    details                  Fetches the detail of an item by its
+                             "seq" number
+    exit-node                Starts an HTTP exit node. Outgoing
+                             traffic from all programs will
+                             be routed through this computer
+    get-transpiled-source    Downloads the transpiled source code of
+    help                     Print this message or the help of the
+                             given subcommand(s)
     kill                     Kill a running program
     login                    Log into your account
     logs                     Stream the logs of a program
     ps                       List running programs
     query                    Queries a program
     repl                     Enter into a program's REPL mode
-    resolve-types            Updates memconfig.lock with the most recent types
-    tag                      Tags a gref so it can be used like `#tag:`
     test                     Runs all tests actions in a program
-    update                   Update a new program
-    workspace-init           Initializes a directory to be a Membrane workspace
-    workspace-path           Prints the path to the workspace
+
 ```
 
 <!-- SUBCOMMANDS -->
@@ -75,24 +68,7 @@ USAGE:
     mctl action <GREF>
 
 ARGS:
-    <GREF>    Gref to invoke action on (TODO: this should include the action and args)
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### assign
-
-```cli-help
-mctl-assign
-Assigns a program to a particular mnode (admin only)
-
-USAGE:
-    mctl assign <PID> [MNODE]
-
-ARGS:
-    <PID>      Program name or id. [default: containing directory name]
-    <MNODE>    The mnode to assign to, or empty if unassigning
+    <GREF>    Gref to invoke action on
 
 OPTIONS:
     -h, --help    Print help information
@@ -106,39 +82,6 @@ Prints the auth token from the config file
 
 USAGE:
     mctl auth-token
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### clone
-
-```cli-help
-mctl-clone
-Clones an existing program creating a brand new one in your workspace and updates it
-
-USAGE:
-    mctl clone <PID> <NAME>
-
-ARGS:
-    <PID>     Program name or id to clone
-    <NAME>    Name of program to create
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### create
-
-```cli-help
-mctl-create
-Create a new program
-
-USAGE:
-    mctl create [PIDS]...
-
-ARGS:
-    <PIDS>...    Program ids to create
 
 OPTIONS:
     -h, --help    Print help information
@@ -165,14 +108,16 @@ OPTIONS:
 
 ```cli-help
 mctl-exit-node
-Starts an HTTP exit node. Outgoing traffic from all programs will be routed through this computer
+Starts an HTTP exit node. Outgoing traffic from all programs will be
+routed through this computer
 
 USAGE:
     mctl exit-node [OPTIONS]
 
 OPTIONS:
     -h, --help                         Print help information
-    -t, --transformer <TRANSFORMER>    A script invoked for every request. It can, for example, add
+    -t, --transformer <TRANSFORMER>    A script invoked for every
+                                       request. It can, for example, add
                                        auth headers
 ```
 
@@ -188,36 +133,6 @@ USAGE:
 ARGS:
     <PID>            Program id to get the source code of
     <OUTPUT_PATH>    Path to store the source code
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### git-clone
-
-```cli-help
-mctl-git-clone
-Clones a program from a github repo to your workspace
-
-USAGE:
-    mctl git-clone <REPO> [NAME]
-
-ARGS:
-    <REPO>    URL of git repo to use or "<user>/<repo>" if using GitHub
-    <NAME>    Name of program to create (defaults to name of repo)
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### ide
-
-```cli-help
-mctl-ide
-Opens your Membrane workspace in Visual Studio Code ensuring the extension is installed
-
-USAGE:
-    mctl ide
 
 OPTIONS:
     -h, --help    Print help information
@@ -310,44 +225,11 @@ USAGE:
     mctl repl [OPTIONS] <PID>
 
 ARGS:
-    <PID>    Program name or id to enter the REPL. [default: containing directory name]
+    <PID>    Program name or id to enter the REPL.
 
 OPTIONS:
     -e, --expression <EXPRESSION>    Optional expression to evaluate
     -h, --help                       Print help information
-```
-
-### resolve-types
-
-```cli-help
-mctl-resolve-types
-Updates memconfig.lock with the most recent types
-
-USAGE:
-    mctl resolve-types [PATH]
-
-ARGS:
-    <PATH>    Path to the program directory [default: .]
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### tag
-
-```cli-help
-mctl-tag
-Tags a gref so it can be used like `#tag:`
-
-USAGE:
-    mctl tag <GREF> <NAME>
-
-ARGS:
-    <GREF>    Gref to query
-    <NAME>    Name of tag
-
-OPTIONS:
-    -h, --help    Print help information
 ```
 
 ### test
@@ -361,49 +243,6 @@ USAGE:
 
 ARGS:
     <PID>    Program id to test
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### update
-
-```cli-help
-mctl-update
-Update a new program
-
-USAGE:
-    mctl update [OPTIONS] <PID>
-
-ARGS:
-    <PID>    Program name or id. [default: containing directory name]
-
-OPTIONS:
-    -h, --help                       Print help information
-        --no-restore <NO_RESTORE>
-```
-
-### workspace-init
-
-```cli-help
-mctl-workspace-init
-Initializes a directory to be a Membrane workspace
-
-USAGE:
-    mctl workspace-init
-
-OPTIONS:
-    -h, --help    Print help information
-```
-
-### workspace-path
-
-```cli-help
-mctl-workspace-path
-Prints the path to the workspace
-
-USAGE:
-    mctl workspace-path
 
 OPTIONS:
     -h, --help    Print help information

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -13,6 +13,28 @@ html {
   --sl-line-height: 1.5;
   --sl-text-code: var(--sl-text-base);
   --sl-text-code-sm: var(--sl-text-sm);
+  --sl-text-sm: 12px;
+  --sl-text-2xs: 12px;
+  --sl-text-xs: 12px;
+  --sl-text-sm: 12px;
+  --sl-text-base: 12px;
+  --sl-text-lg: 12px;
+  --sl-text-xl: 12px;
+  --sl-text-2xl: 12px;
+  --sl-text-3xl: 12px;
+  --sl-text-4xl: 12px;
+  --sl-text-5xl: 12px;
+  --sl-text-6xl: 12px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 12px !important;
+  text-transform: uppercase;
 }
 
 /* Dark mode colors. */
@@ -103,15 +125,12 @@ li > a {
   width: calc(100% - 8px);
   max-width: 720px;
   object-fit: cover;
-  padding: 8px;
+  padding: 20px;
   margin: 16px 0 32px 0;
   border: 1px solid var(--sl-color-accent-high);
-  box-shadow:
-    1px 1px var(--sl-color-accent-high),
-    2px 2px var(--sl-color-accent-high),
-    3px 3px var(--sl-color-accent-high),
-    4px 4px var(--sl-color-accent-high),
-    5px 5px var(--sl-color-accent-high);
+  box-shadow: 1px 1px var(--sl-color-accent-high),
+    2px 2px var(--sl-color-accent-high), 3px 3px var(--sl-color-accent-high),
+    4px 4px var(--sl-color-accent-high), 5px 5px var(--sl-color-accent-high);
 }
 
 /* Customize pagination link buttons */
@@ -138,4 +157,16 @@ p {
 
 :root[data-theme="dark"] starlight-menu-button > button > svg {
   color: white;
+}
+
+.large {
+  text-transform: uppercase;
+}
+
+/* This is important so that the JSDoc hovers are not clipped but it forces us to
+ * keep our code blocks to ~70 characters wide
+ */
+.astro-code {
+  overflow: visible !important;
+  font-size: 11px !important;
 }

--- a/src/styles/copy-button.css
+++ b/src/styles/copy-button.css
@@ -4,8 +4,8 @@ pre:has(code) {
 
 pre button.copy {
   position: absolute;
-  right: 10px;
-  top: 10px;
+  right: 4px;
+  top: 4px;
   height: 24px;
   width: 24px;
   padding: 0;
@@ -32,12 +32,18 @@ pre button.copy {
     cursor: pointer;
     background-color: var(--sl-color-text-accent);
     mask-image: url(../assets/icons/clipboard.svg);
+    mask-size: 50%;
+    mask-repeat: no-repeat;
+    mask-position: center;
   }
 
   & .success {
     display: none;
     background-color: var(--sl-color-text-accent);
     mask-image: url(../assets/icons/copy-success.svg);
+    mask-size: 50%;
+    mask-repeat: no-repeat;
+    mask-position: center;
   }
 
   &.copied {


### PR DESCRIPTION
Based on the realization that using different font-sizes is what makes the design look different from the main website.

I changed all text to use the same font size. This should also make it look better when embedded in the IDE.

Other changes:
 - Replaces `Membrane-isms` with `Concepts`. I like the term but I felt it was hard to parse and understand what that section was about and I feel like Concepts is pretty standard.
 - Opened all sections by default since we don't have that many pages.
 - Fixed an issue with hovering of code blocks getting clipped.
   ![Screenshot 2024-11-26 at 14 33 22](https://github.com/user-attachments/assets/7ace98e9-ca42-47b3-a1cf-7b360a872d5b)
 - Fixed link to github repo which was pointing to starlight's repo 😅 
 - Small rewrites here and there.

### Before
![Screenshot 2024-11-26 at 14 08 13](https://github.com/user-attachments/assets/e4c20ea4-4b51-426a-8b69-51025111a321)

### After
![Screenshot 2024-11-26 at 14 08 38](https://github.com/user-attachments/assets/dc2ff09a-7d71-4d80-a26f-81546199825e)

