### PR TITLE
Fix color contrast for light mode search highlights

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -509,4 +509,11 @@ import { Icon } from "@astrojs/starlight/components";
           font-weight: 600;
       }
   }
+
+  :root[data-theme="light"] #starlight__search {
+    & mark {
+      color: #63f !important;
+    }
+  }
+  
 </style>


### PR DESCRIPTION
| Before | After |
| -- | -- |
| <img width="874" alt="Screenshot 2025-01-09 at 4 11 06 PM" src="https://github.com/user-attachments/assets/297b2eb6-dbe2-431e-af5e-725967ba5df5" /> | <img width="873" alt="Screenshot 2025-01-09 at 4 10 51 PM" src="https://github.com/user-attachments/assets/a693ee05-f2d1-4dad-94a0-ded94cbf716e" /> |
| <img width="276" alt="Screenshot 2025-01-09 at 4 11 27 PM" src="https://github.com/user-attachments/assets/bd5b7ad0-b300-4b6e-8677-ea3006791514" /> | <img width="278" alt="Screenshot 2025-01-09 at 4 12 04 PM" src="https://github.com/user-attachments/assets/22384238-9b17-48f7-8166-7aad1a95f983" /> |
