### PR TITLE
Add timer delay options and other minor fixes

### DIFF
--- a/src/content/docs/guides/driver-guide.md
+++ b/src/content/docs/guides/driver-guide.md
@@ -88,7 +88,7 @@ export async function configure({ apiKey }: { apiKey: string }) {
 
 ```
 
-### `helper.ts`
+### helper.ts
 
 As a convention, utility functions live in `helpers.ts`. For this driver, we
 have an `api` function that calls `fetch` with the appropriate headers, query
@@ -475,9 +475,11 @@ export const Resource = {
 ## 4. Publishing Your Driver
 
 1. Include a README.md with:
+
    - Configuration steps
    - Basic usage examples
    - Available methods
+
 2. Test before publishing:
 
    ```js
@@ -494,23 +496,18 @@ within the Membrane ecosystem.
 As you build more drivers and connect more services, you'll unlock increasingly
 powerful automation and integration possibilities.
 
-## 5. Troubleshooting
-
-Get started with our [driver-template]
-
 <aside>
 💡
 
 We are working on a way to speed up the driver development process by generating
-drivers using LLM’s and API specs. You can install the driver-generator program
-[here].
+drivers using LLM’s and API specs.
 
 </aside>
 
-## 6. Missing a Driver?
+## 5. Missing a Driver?
 
 Missing a driver for one of your favorite APIs?
 
-- Request it in the [community](https://discord.gg/gBK9xP3z)
-- Contribute it! You can get started with our [template] or try out the
-  [driver-generator].
+- Request it in our [community](https://discord.gg/gBK9xP3z), or let us build it for you - just reach out at
+  [contact@membrane.io](mailto:contact@membrane.io).
+- Contribute it!

--- a/src/content/docs/guides/timers.md
+++ b/src/content/docs/guides/timers.md
@@ -16,6 +16,18 @@ to configure when the program should run. Right click a timer to delete.
 Example: add a cron, delete it, then add a delay and observe it firing.
 <video src="/videos/timers.mp4" muted autoplay controls></video>
 
+## Delay Timer Options
+
+When using "Invoke after delay...", you can specify durations using these time units:
+
+- `s` - seconds (e.g. "10s")
+- `m` - minutes (e.g. "5m")
+- `h` - hours (e.g. "12h")
+- `d` - days (e.g. "7d")
+- `w` - weeks (e.g. "2w")
+- `ms` - milliseconds (e.g. "500ms")
+- `ns` - nanoseconds (e.g. "100ns")
+
 ## Setting timers in code
 
 You can also set up timers programmatically in Membrane. These three methods can


### PR DESCRIPTION
See -> https://membrane.height.app/T-1343

During my meeting with Top we went through the getting-started program and when we got to the "Timers" section he was confused what we could input into "Invoke after delay..." We went to the docs and there was no info on what time units we could use for the delay. 

This PR includes a list of the options of time units we can use for the delay. I also removed the broken links from the driver guide and made some other small changes there.

TIL about fundu: https://docs.rs/fundu/latest/fundu/